### PR TITLE
Remove google analytics

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,5 @@
 //= require turbolinks
 //= require js-routes
 //= require bootstrap-sprockets
-//= require google_analytics
 //= require_tree .
 //= require_tree ../../../vendor/assets/javascripts/.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,7 @@ class ApplicationController < ActionController::Base
   def csp_headers
     response.headers['Content-Security-Policy-Report-Only'] =
       "default-src 'self'; " \
+      "script-src 'self' 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; " \
       "font-src 'self' fonts.gstatic.com; " \
       "style-src 'self' 'unsafe-inline'; " \
       'object-src; ' \

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,6 @@ class ApplicationController < ActionController::Base
   def csp_headers
     response.headers['Content-Security-Policy-Report-Only'] =
       "default-src 'self'; " \
-      "script-src 'self' www.google-analytics.com 'sha256-1kYydMhZjhS1eCkHYjBthAOfULylJjbss3YE6S2CGLc=' 'unsafe-eval'; " \
       "font-src 'self' fonts.gstatic.com; " \
       "style-src 'self' 'unsafe-inline'; " \
       'object-src; ' \

--- a/vendor/assets/javascripts/google_analytics.js
+++ b/vendor/assets/javascripts/google_analytics.js
@@ -1,7 +1,0 @@
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-79843977-1', 'auto');
-  ga('send', 'pageview');


### PR DESCRIPTION
Replaces the 'script src' line. Just removes the google analytics part.

This pull request makes the following changes:

- app/controller/application_controller.rb 

It relates to the following issue #s: 

- Fixes Remove google analytics #997
